### PR TITLE
Remove all other payments before going ahead with Paypal payment

### DIFF
--- a/lib/spree/paypal_express.rb
+++ b/lib/spree/paypal_express.rb
@@ -37,6 +37,10 @@ module Spree::PaypalExpress
   #
   def paypal_payment
     load_object
+
+    # Remove all other payments
+    @checkout.order.payments.clear
+
     opts = all_opts(@order,params[:payment_method_id], 'payment')
     opts.merge!(address_options(@order))
     gateway = paypal_gateway


### PR DESCRIPTION
In CheckoutsController there is a before hook on #update that clears all other payments. It doesn't cover paypal_payment so when a failed CC payment (for example) isn't cleared it will cause the Checkout/Order finalization to fail.
